### PR TITLE
refactor: improve model detection and reuse environment variables for version parsing

### DIFF
--- a/getdomains-check.sh
+++ b/getdomains-check.sh
@@ -19,7 +19,7 @@ output_21() {
 }
 
 # System Details
-MODEL=$(grep machine /proc/cpuinfo | cut -d ':' -f 2)
+MODEL=$(cat /tmp/sysinfo/model)
 RELEASE=$(grep OPENWRT_RELEASE /etc/os-release | awk -F '"' '{print $2}')
 printf "\033[34;1mModel:$MODEL\033[0m\n"
 printf "\033[34;1mVersion: $RELEASE\033[0m\n"

--- a/getdomains-check.sh
+++ b/getdomains-check.sh
@@ -20,12 +20,12 @@ output_21() {
 
 # System Details
 MODEL=$(cat /tmp/sysinfo/model)
-RELEASE=$(grep OPENWRT_RELEASE /etc/os-release | awk -F '"' '{print $2}')
-printf "\033[34;1mModel:$MODEL\033[0m\n"
-printf "\033[34;1mVersion: $RELEASE\033[0m\n"
+source /etc/os-release
+printf "\033[34;1mModel: $MODEL\033[0m\n"
+printf "\033[34;1mVersion: $OPENWRT_RELEASE\033[0m\n"
 printf "\033[34;1mDate: $(date)\033[0m\n"
 
-VERSION_ID=$(grep VERSION_ID /etc/os-release | awk -F '"' '{print $2}' | awk -F. '{print $1}')
+VERSION_ID=$(cat $VERSION | awk -F. '{print $1}')
 RAM=$(free -m | grep Mem: | awk '{print $2}')
 if [[ "$VERSION_ID" -ge 22 && "$RAM" -lt 150000 ]]
 then 

--- a/getdomains-check.sh
+++ b/getdomains-check.sh
@@ -25,7 +25,7 @@ printf "\033[34;1mModel: $MODEL\033[0m\n"
 printf "\033[34;1mVersion: $OPENWRT_RELEASE\033[0m\n"
 printf "\033[34;1mDate: $(date)\033[0m\n"
 
-VERSION_ID=$(cat $VERSION | awk -F. '{print $1}')
+VERSION_ID=$(echo $VERSION | awk -F. '{print $1}')
 RAM=$(free -m | grep Mem: | awk '{print $2}')
 if [[ "$VERSION_ID" -ge 22 && "$RAM" -lt 150000 ]]
 then 

--- a/getdomains-install.sh
+++ b/getdomains-install.sh
@@ -893,7 +893,7 @@ add_internal_wg() {
 }
 
 # System Details
-MODEL=$(grep machine /proc/cpuinfo | cut -d ':' -f 2)
+MODEL=$(cat /tmp/sysinfo/model)
 RELEASE=$(grep OPENWRT_RELEASE /etc/os-release | awk -F '"' '{print $2}')
 printf "\033[34;1mModel:$MODEL\033[0m\n"
 printf "\033[34;1mVersion: $RELEASE\033[0m\n"

--- a/getdomains-install.sh
+++ b/getdomains-install.sh
@@ -894,11 +894,11 @@ add_internal_wg() {
 
 # System Details
 MODEL=$(cat /tmp/sysinfo/model)
-RELEASE=$(grep OPENWRT_RELEASE /etc/os-release | awk -F '"' '{print $2}')
-printf "\033[34;1mModel:$MODEL\033[0m\n"
-printf "\033[34;1mVersion: $RELEASE\033[0m\n"
+source /etc/os-release
+printf "\033[34;1mModel: $MODEL\033[0m\n"
+printf "\033[34;1mVersion: $OPENWRT_RELEASE\033[0m\n"
 
-VERSION_ID=$(grep VERSION_ID /etc/os-release | awk -F '"' '{print $2}' | awk -F. '{print $1}')
+VERSION_ID=$(echo $VERSION | awk -F. '{print $1}')
 
 if [ "$VERSION_ID" -ne 23 ]; then
     printf "\033[31;1mScript only support OpenWrt 23.05\033[0m\n"


### PR DESCRIPTION
На некоторых устройствах, таких как `Xiaomi Mi Router AX3000T`, информация о модели не выводится при использовании команды, читающей `/proc/cpuinfo`:

```
root@OpenWrt:/tmp# cat /proc/cpuinfo
processor	: 0
BogoMIPS	: 26.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 1
BogoMIPS	: 26.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4
```

Из-за чего в скриптах `getdomains-install.sh` и `getdomains-check.sh` не выводится модель роутера:

```
Model:
Version: OpenWrt 23.05.4 r24012-d8dd03c46f
```

Теперь модель устройства извлекается из файла `/tmp/sysinfo/model`, а вместо дублирования кода для парсинга версии OpenWrt используются переменные окружения напрямую из файла `/etc/os-release`.